### PR TITLE
Using Dockerfile from root project

### DIFF
--- a/docker-example/docker-compose.yml
+++ b/docker-example/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - statusd
     build:
       context: ../
-      dockerfile: _assets/Dockerfile
+      dockerfile: Dockerfile
     volumes:
       - ./data/statusd-data:/statusd-data
     command: geth_exporter -ipc /statusd-data/geth.ipc


### PR DESCRIPTION
If you try to run `docker-compose up` inside `docker-example` you will have the following error:
`ERROR: Cannot locate specified Dockerfile: _assets/Dockerfile`


Important changes:
- Using `Dockerfile`  from Project Root instead of `_assets/Dockerfile` which doesn't exist

